### PR TITLE
LIBITD-419. Fixed missing image in production environment

### DIFF
--- a/app/views/layouts/_umd_lib.html.erb
+++ b/app/views/layouts/_umd_lib.html.erb
@@ -22,7 +22,7 @@
       <div id="navbar" class="navbar-collapse collapse">
         <%= yield :navbar %>
         <div class="navbar-right logo">
-          <a href="http://www.lib.umd.edu/"><%= image_tag 'liblogo', alt: 'UMD Libraries' %></a>
+          <a href="http://www.lib.umd.edu/"><%= image_tag 'liblogo.png', alt: 'UMD Libraries' %></a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
In the production environment, the assets may be pre-compiled,
resulting in files with checksums appended to them.

Apparently the "image_tag" must include the file extension in
order for the Rails asset pipeline to find the file.

https://issues.umd.edu/browse/LIBITD-419
