### PR TITLE
LIBITD-663. Place environment banner inside navigation bar and at the top of the page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,16 @@ Displays a full page width banner directly below the navbar, which will not scro
 <% end %>
 ```
 
+### Environment Banner
+
+In keeping with [SSDR policy][2], an "environment banner" will be displayed at the top of each page when running on non-production servers, indicating whether the application is running on a "Local", "Development", or "Staging" server. This banner does _not_ appear on production systems.
+
+The environment banner will attempt to auto-detect the correct environment. To override this auto-detection functionality (or to modify it for testing), an "ENVIRONMENT_BANNER" environment banner can be used with any of the following values (which are case-insensitive):
+
+ * "Local"
+ * "Development"
+ * "Staging"
+ * "Production" - This is only needed to force the "production" setting (i.e., not show the banner) on a server that would otherwise show some other value. Production systems do _not_ need to set this value.
+
 [1]: https://github.com/twbs/bootstrap-sass/archive/v3.3.6.tar.gz
+[2]: https://confluence.umd.edu/display/LIB/Create+Environment+Banners

--- a/app/helpers/umd_lib_environment_banner_helper.rb
+++ b/app/helpers/umd_lib_environment_banner_helper.rb
@@ -1,20 +1,31 @@
 module UMDLibEnvironmentBannerHelper
   # https://confluence.umd.edu/display/LIB/Create+Environment+Banners
   def umd_lib_environment_banner
-    if Rails.env.development?
-      environment = 'Local'
-    else
-      hostname = `hostname -s`
-      if hostname =~ /dev$/
-        environment = 'Development'
-      elsif hostname =~ /stage$/
-        environment = 'Staging'
-      end
-    end
     if environment
       content_tag :div, "#{environment} Environment",
         class: 'environment-banner',
         id: "environment-#{environment.downcase}"
     end
+  end
+
+  # Returns 'Local', 'Development', 'Staging', or nil (indicating a production
+  # server), depending on the server environment.
+  #
+  # The "ENVIRONMENT_BANNER" environment variable can optionally be used to
+  # force a particular environment setting. Use "Production" to
+  # indicate a production system on non-production servers.
+  def environment
+    # Allow override using "ENVIRONMENT_BANNER" environment variable.
+    env_var = ENV['ENVIRONMENT_BANNER']
+    return nil if !env_var.nil? && env_var.downcase == 'production'
+    return env_var if !env_var.blank?
+    
+    return 'Local' if Rails.env.development?
+    
+    hostname = `hostname -s`
+    return 'Development' if hostname =~ /dev$/
+    return 'Staging' if hostname =~ /stage$/
+    
+    # Otherwise return nil, indicating production
   end
 end

--- a/app/views/layouts/_umd_lib.html.erb
+++ b/app/views/layouts/_umd_lib.html.erb
@@ -7,8 +7,27 @@
   <%= csrf_meta_tags %>
 </head>
 <body role="document">
-  <%= umd_lib_environment_banner %>
   <nav class="navbar navbar-inverse navbar-fixed-top">
+    <%= umd_lib_environment_banner %>
+    
+    <!-- The following script changes the padding of the body, if the
+         environment banner is present. -->
+    <script>
+      var bannerDiv = document.getElementsByClassName("environment-banner")[0];
+      if (bannerDiv) {
+        var bannerStyle = bannerDiv.currentStyle || window.getComputedStyle(bannerDiv);
+        var bannerHeight = parseInt(bannerStyle.height, 10);
+        
+        var bodyElement = document.body;
+        var bodyStyle = bodyElement.currentStyle || window.getComputedStyle(bodyElement);
+        var bodyPaddingTop = parseInt(bodyStyle.paddingTop, 10);
+        
+        var newBodyPaddingTop = bodyPaddingTop + bannerHeight;
+        var newBodyPaddingTopStr = "padding-top: "+newBodyPaddingTop + "px !important;";
+        bodyElement.setAttribute('style', newBodyPaddingTopStr);
+      }
+    </script>
+    
     <div class="container">
       <div class="navbar-header">
         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">


### PR DESCRIPTION
Modified the umd_lib_style gem to include an "environment banner" at the top of the page, and inside the navigation bar, to be displayed when the application is running on a non-production server.

https://issues.umd.edu/browse/LIBITD-663