### PR TITLE
LIBITD-695. Fix vertical "bounce" when using environment banner.

### DIFF
--- a/app/assets/stylesheets/umd_lib.scss
+++ b/app/assets/stylesheets/umd_lib.scss
@@ -28,7 +28,7 @@ body {
   padding-top: $navbar-height + 10px !important;
 }
 
-extra-padding-top {
+.extra-padding-top {
   padding-top: $navbar-height + $env-banner-height + 10px !important;
 }
 

--- a/app/assets/stylesheets/umd_lib.scss
+++ b/app/assets/stylesheets/umd_lib.scss
@@ -10,6 +10,8 @@ $navbar-height: $logo-height + 10px;
 
 $grid-float-breakpoint: 1200px !default;
 
+$env-banner-height: 25px;
+
 @import "bootstrap-sprockets";
 @import "bootstrap";
 @import "umd_lib_environment_banner";
@@ -24,6 +26,10 @@ $grid-float-breakpoint: 1200px !default;
 
 body {
   padding-top: $navbar-height + 10px !important;
+}
+
+extra-padding-top {
+  padding-top: $navbar-height + $env-banner-height + 10px !important;
 }
 
 .btn-group {

--- a/app/assets/stylesheets/umd_lib_environment_banner.scss
+++ b/app/assets/stylesheets/umd_lib_environment_banner.scss
@@ -1,6 +1,6 @@
 // https://confluence.umd.edu/display/LIB/Create+Environment+Banners
 .environment-banner {
-    height: 25px;
+    height: $env-banner-height;
     padding: 2px 25px;
 
     &#environment-local {

--- a/app/helpers/umd_lib_environment_banner_helper.rb
+++ b/app/helpers/umd_lib_environment_banner_helper.rb
@@ -8,6 +8,14 @@ module UMDLibEnvironmentBannerHelper
     end
   end
 
+  # When the banner is visible, add the extra-padding-top class
+  # to increase body padding
+  def extra_padding_top 
+    if environment
+      return 'extra-padding-top'
+    end
+  end
+
   # Returns 'Local', 'Development', 'Staging', or nil (indicating a production
   # server), depending on the server environment.
   #
@@ -28,4 +36,5 @@ module UMDLibEnvironmentBannerHelper
     
     # Otherwise return nil, indicating production
   end
+
 end

--- a/app/views/layouts/_umd_lib.html.erb
+++ b/app/views/layouts/_umd_lib.html.erb
@@ -6,27 +6,9 @@
   <%= javascript_include_tag 'application' %>
   <%= csrf_meta_tags %>
 </head>
-<body role="document">
+<body role="document" class="<%= extra_padding_top %>">
   <nav class="navbar navbar-inverse navbar-fixed-top">
     <%= umd_lib_environment_banner %>
-    
-    <!-- The following script changes the padding of the body, if the
-         environment banner is present. -->
-    <script>
-      var bannerDiv = document.getElementsByClassName("environment-banner")[0];
-      if (bannerDiv) {
-        var bannerStyle = bannerDiv.currentStyle || window.getComputedStyle(bannerDiv);
-        var bannerHeight = parseInt(bannerStyle.height, 10);
-        
-        var bodyElement = document.body;
-        var bodyStyle = bodyElement.currentStyle || window.getComputedStyle(bodyElement);
-        var bodyPaddingTop = parseInt(bodyStyle.paddingTop, 10);
-        
-        var newBodyPaddingTop = bodyPaddingTop + bannerHeight;
-        var newBodyPaddingTopStr = "padding-top: "+newBodyPaddingTop + "px !important;";
-        bodyElement.setAttribute('style', newBodyPaddingTopStr);
-      }
-    </script>
     
     <div class="container">
       <div class="navbar-header">


### PR DESCRIPTION
Added a CSS class to be applied to the body tag to increase the padding-top when environment banner is used.

https://issues.umd.edu/browse/LIBITD-695