### PR TITLE
LIBITD-1088, Updated version.rb version to "1.0.1"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,30 @@
 
 Gem containing the common UMD Libraries Rails application layout and styles. Built on Bootstrap 3.3.6.
 
+## Git Tagging
+
+When a new version of this gem is created, be sure to update the version
+number in the lib/umd_style/version.rb to match the Git tag.
+
 ## Usage
 
 In your app's Gemfile:
 
 ```ruby
 gem 'umd_lib_style', github: 'umd-lib/umd_lib_style', branch: 'develop'
+```
+
+to use the "develop" branch version of the gem, or
+
+```ruby
+gem 'umd_lib_style', github: 'umd-lib/umd_lib_style', ref: '<GIT_TAG>'
+```
+
+where <GIT_TAG> is the Git tag of the version to use. For example, to use
+the Git tagged "1.0.1" version, use:
+
+```ruby
+gem 'umd_lib_style', github: 'umd-lib/umd_lib_style', ref: '1.0.1'
 ```
 
 Then run the usual:

--- a/lib/umd_lib_style/version.rb
+++ b/lib/umd_lib_style/version.rb
@@ -1,3 +1,3 @@
 module UMDLibStyle
-  VERSION = "0.2.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
Changed VERSION value in the lib/umd_lib_style/version.rb
file to "1.0.1" so that it will match the Git tag.

Updated the README.md with a reminder to update the
the lib/umd_lib_style/version.rb file when creating new
versions, and additional information for checking out
a particular Git tagged version in projects.

https://issues.umd.edu/browse/LIBITD-1088