### PR TITLE
LIBITD-1112 Implement "sticky footer" from LIBWEB-4068 in umd_lib_style

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,26 +131,5 @@ file.
 <% end %>
 ```
 
-The height of the footer is fixed at 45 pixels, with 10 pixels of top and bottom
-padding, and a 1 pixel top border. If an application needs to change the height
-of the footer, or any of the padding, the "padding-bottom" parameter of the
-"content" class should also be changed to match the total height of the
-footer (i.e., $footer-height + (2 * $footer-padding-size) + $footer-border-size).
- For example, to change the height of the "footer"
-class to 60 pixels, add the following to the application's CSS file:
-
-```css
-.content {
-  padding-bottom: 81px; // 60 + (2 * 10) + 1
-}
-
-.footer {
-  height: 60px;
-  border-top: 1px solid #999999;
-  padding: 10px 0;
-}
-```
-
-
 [1]: https://github.com/twbs/bootstrap-sass/archive/v3.3.6.tar.gz
 [2]: https://confluence.umd.edu/display/LIB/Create+Environment+Banners

--- a/app/assets/stylesheets/umd_lib.scss
+++ b/app/assets/stylesheets/umd_lib.scss
@@ -12,7 +12,6 @@ $grid-float-breakpoint: 1200px !default;
 
 $env-banner-height: 25px;
 
-$footer-height: 45px;
 $footer-padding-size: 10px;
 $footer-padding: $footer-padding-size 0;
 $footer-border-size: 1px;
@@ -48,10 +47,6 @@ body {
   padding-top: $navbar-height + $env-banner-height + 10px !important;
 }
 
-.content {
-  padding-bottom: $footer-height + ($footer-padding-size * 2) +$footer-border-size;
-}
-
 .btn-group {
   // remove the extra margins from the will_paginate widget
   // so it will align with the other buttons in the toolbar
@@ -71,9 +66,6 @@ body {
 .footer {
   background-color: #f5f5f5;
   border-top: $footer-border-size solid #999999;
-  height: $footer-height;
-  position: absolute;
-  bottom: 0;
   width: 100%;
   padding: $footer-padding;
 
@@ -81,6 +73,26 @@ body {
     color: #035E8C;
     font-weight: 500;
   }
+}
+
+.site {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+}
+
+.site-content {
+  -webkit-box-flex: 1;
+  -webkit-flex: 1 0 auto;
+  -ms-flex: 1 0 auto;
+  flex: 1 0 auto;
 }
 
 @media (min-width: $grid-float-breakpoint) {

--- a/app/views/layouts/_umd_lib.html.erb
+++ b/app/views/layouts/_umd_lib.html.erb
@@ -7,10 +7,10 @@
   <%= csrf_meta_tags %>
 </head>
 <body role="document">
-  <div id="viewport" class="<%= extra_padding_top %>">
+  <div id="viewport" class="<%= extra_padding_top %> site">
     <nav class="navbar navbar-inverse navbar-fixed-top">
       <%= umd_lib_environment_banner %>
-      
+
       <div class="container">
         <div class="navbar-header">
           <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
@@ -32,20 +32,20 @@
       </div>
       <%= yield :navbar_banner %>
     </nav>
-    
-    <div class="content">
+
+    <div class="content site-content">
       <div class="<%= content_for?(:container_class) ? yield(:container_class) : "container"  %>">
         <% if notice %>
           <div class="alert alert-success" role="alert"><%= notice %></div>
         <% end %>
-    
+
         <%= yield %>
       </div>
     </div>
-    
+
     <% if content_for?(:application_footer) %>
       <%= yield :application_footer %>
-    <% else %>    
+    <% else %>
       <footer class="footer">
         <div class="<%= content_for?(:container_class) ? yield(:container_class) : "container"  %>">
           <a class="pull-right" href="https://umd.edu/web-accessibility" target="_blank">Web Accessibility</a>


### PR DESCRIPTION
Updated umd_lib_style to use "sticky footer" from LIBWEB-4068.

Note: Due to the way the page layout is in umd_lib_style, the
"site" class was placed on the "viewport" div (not the "body" div), and
the "site-content" class simply replaced on the "content" class, not
the div with the "container" class.

Removed old footer sizing CSS and "content" definition from umd_lib.scss,
as it is no longer needed.

Updated documentation.

https://issues.umd.edu/browse/LIBITD-1112