### PR TITLE
LIBITD-1794. Refactored environment banner for Kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+## Introduction
+
+This document records notable changes to the functionality of this gem.
+
+Note: Only changes that affect behavior need to be recorded.
+
+## 2.0.0
+
+* API-breaking change to the behavior of the environment banner. The
+  environment banner no longer uses the hostname in setting the banner,
+  instead relying on environment variables for configuring the banner
+  on non-development system. See the README.md for more details.
+
+  For local development, a "Local Environment" banner is displayed by default.
+
+## 1.2.0
+
+* Additional directives can now be added to HTML "head" section.
+
+## 1.1.0
+
+* Implemented "sticky footer"
+
+## 1.0.1
+
+* No functionality changes.
+
+## 1.0.0
+
+* Initial implementation

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 Gem containing the common UMD Libraries Rails application layout and styles.
 Built on Bootstrap 3.3.6.
 
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for information about changes to this gem.
+
 ## Git Tagging
 
 When a new version of this gem is created, be sure to update the version
@@ -77,7 +81,7 @@ sections of the layout.
 Enables additional directives to be added into the "head" section of the HTML
 page.
 
-#### Sample Usage
+#### Additional "head" content - Sample Usage
 
 In Rails 5.2, an additional "csp_meta" tag is added into the "head" section of
 the layouts/application.html.erb file. To include this tag into a Rails
@@ -95,8 +99,7 @@ application using this gem, add a `content_for` block to your
 This gem provides a fixed full page width navigation bar at the top of the page,
 containing the application name and a set of drop-down menus.
 
-
-#### Sample Usage
+#### Custom Navbar - Sample Usage
 
 The application name is set using a "app_name" block. To include your own custom
 markup in the navbar, add a `content_for` block to your
@@ -122,7 +125,7 @@ Displays a full page width banner directly below the navbar, which will not
 scroll off the screen. Used by the Annual Staffing Request application to show a
 banner when impersonating another user.
 
-#### Sample Usage
+#### Custom Nav Banner - Sample Usage
 
 ```erb
 <% content_for :navbar_banner do %>
@@ -133,21 +136,22 @@ banner when impersonating another user.
 ### Environment Banner
 
 In keeping with [SSDR policy][2], an "environment banner" will be displayed at
-the top of each page when running on non-production servers, indicating whether
-the application is running on a "Local", "Development", or "Staging" server.
-This banner does _not_ appear on production systems.
+the top of each page when running on non-production servers.
 
-The environment banner will attempt to auto-detect the correct environment. To
-override this auto-detection functionality (or to modify it for testing), an
-"ENVIRONMENT_BANNER" environment banner can be used with any of the following
-values (which are case-insensitive):
+By default, in the local development environment (determined by
+`Rails.env.development?` returning `true`), a "Local Environment" banner will be
+displayed.
 
-* "Local"
-* "Development"
-* "Staging"
-* "Production" - This is only needed to force the "production" setting (i.e.,
-not show the banner) on a server that would otherwise show some other value.
-Production systems do _not_ need to set this value.
+On non-production servers, the environment banner can be configured using the
+following environment variables:
+
+* ENVIRONMENT_BANNER - the text to display in the banner
+* ENVIRONMENT_BANNER_FOREGROUND - the foreground color for the banner, as a CSS
+  color
+* ENVIRONMENT_BANNER_BACKGROUND - the background color for the banner, as a CSS
+  color
+* ENVIRONMENT_BANNER_ENABLED - (optional) Anything other than "true" disables
+  the banner.
 
 ### Page Content Container class
 
@@ -168,7 +172,7 @@ default. Applications wishing to override the default footer can do so by
 defining a "content_for" block to your *app/views/layout/application.html.erb*
 file.
 
-#### Sample Usage
+#### Footer - Sample Usage
 
 ```erb
 <% content_for :application_footer do %>

--- a/README.md
+++ b/README.md
@@ -150,8 +150,9 @@ following environment variables:
   color
 * ENVIRONMENT_BANNER_BACKGROUND - the background color for the banner, as a CSS
   color
-* ENVIRONMENT_BANNER_ENABLED - (optional) Anything other than "true" (or blank)
-  disables the banner.
+* ENVIRONMENT_BANNER_ENABLED - (optional) "false" (case-sensitive) disables the
+  banner. Anything else (including blank, or not providing the variable) enables
+  the banner.
 
 ### Page Content Container class
 

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ following environment variables:
   color
 * ENVIRONMENT_BANNER_BACKGROUND - the background color for the banner, as a CSS
   color
-* ENVIRONMENT_BANNER_ENABLED - (optional) Anything other than "true" disables
-  the banner.
+* ENVIRONMENT_BANNER_ENABLED - (optional) Anything other than "true" (or blank)
+  disables the banner.
 
 ### Page Content Container class
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # UMD Lib Style
 
-Gem containing the common UMD Libraries Rails application layout and styles. Built on Bootstrap 3.3.6.
+Gem containing the common UMD Libraries Rails application layout and styles.
+Built on Bootstrap 3.3.6.
 
 ## Git Tagging
 
@@ -34,12 +35,14 @@ Then run the usual:
 $ bundle install
 ```
 
-Finally, edit your app's application files to use the scripts, styles, and layouts:
+Finally, edit your app's application files to use the scripts, styles, and
+layouts:
 
 1. Add `//= require umd_lib` to *app/assets/javascripts/application.js*
 2. Rename *app/assets/stylesheets/application.css* to *application.scss*
 3. Add `@import "umd_lib";` to *app/assets/stylesheets/application.scss*
-4. Change the contents of *app/views/layouts/application.html.erb* to the following:
+4. Change the contents of *app/views/layouts/application.html.erb* to the
+following:
 
     ```erb
     <% provide :app_name, 'My UMD Libraries App' %>
@@ -48,19 +51,26 @@ Finally, edit your app's application files to use the scripts, styles, and layou
 
 ## Bootstrap Notes
 
-This gem uses [Bootstrap SASS version 3.3.6][1]. The Bootstrap assets are copied directly into the [vendor/assets](vendor/assets) directory.
+This gem uses [Bootstrap SASS version 3.3.6][1]. The Bootstrap assets are copied
+directly into the [vendor/assets](vendor/assets) directory.
 
-If you are starting from an app that already loaded Bootstrap directly into your CSS or Javascript, you must *replace* the relevant `require` or `@import` statements with the ones to load `umd_lib` listed above.
+If you are starting from an app that already loaded Bootstrap directly into your
+CSS or Javascript, you must *replace* the relevant `require` or `@import`
+statements with the ones to load `umd_lib` listed above.
 
-In addition, your app will no longer need the `bootstrap-sass` gem and you can remove it from your Gemfile.
+In addition, your app will no longer need the `bootstrap-sass` gem and you can
+remove it from your Gemfile.
 
 ## Scaffolding CSS
 
-If you generated your app with Rails scaffolding, you should remove the *app/assets/stylesheets/scaffold.css.scss* file, to remove any potential conflicts with the Bootstrap styles.
+If you generated your app with Rails scaffolding, you should remove the
+*app/assets/stylesheets/scaffold.css.scss* file, to remove any potential
+conflicts with the Bootstrap styles.
 
 ## content_for blocks
 
-The "content_for" block allows for additions/customization of particular sections of the layout.
+The "content_for" block allows for additions/customization of particular
+sections of the layout.
 
 ### Additional "head" content - additional_head_content
 
@@ -82,11 +92,15 @@ application using this gem, add a `content_for` block to your
 
 ### Custom Navbar - navbar
 
-This gem provides a fixed full page width navigation bar at the top of the page, containing the application name and a set of drop-down menus.
+This gem provides a fixed full page width navigation bar at the top of the page,
+containing the application name and a set of drop-down menus.
+
 
 #### Sample Usage
 
-The application name is set using a "app_name" block. To include your own custom markup in the navbar, add a `content_for` block to your *app/views/layout/application.html.erb* file.
+The application name is set using a "app_name" block. To include your own custom
+markup in the navbar, add a `content_for` block to your
+*app/views/layout/application.html.erb* file.
 
 ```erb
 <% provide :app_name, 'Autonumber Service' %>
@@ -104,7 +118,9 @@ The application name is set using a "app_name" block. To include your own custom
 
 ### Custom Nav Banner - "navbar_banner"
 
-Displays a full page width banner directly below the navbar, which will not scroll off the screen. Used by the Annual Staffing Request application to show a banner when impersonating another user.
+Displays a full page width banner directly below the navbar, which will not
+scroll off the screen. Used by the Annual Staffing Request application to show a
+banner when impersonating another user.
 
 #### Sample Usage
 
@@ -116,18 +132,30 @@ Displays a full page width banner directly below the navbar, which will not scro
 
 ### Environment Banner
 
-In keeping with [SSDR policy][2], an "environment banner" will be displayed at the top of each page when running on non-production servers, indicating whether the application is running on a "Local", "Development", or "Staging" server. This banner does _not_ appear on production systems.
+In keeping with [SSDR policy][2], an "environment banner" will be displayed at
+the top of each page when running on non-production servers, indicating whether
+the application is running on a "Local", "Development", or "Staging" server.
+This banner does _not_ appear on production systems.
 
-The environment banner will attempt to auto-detect the correct environment. To override this auto-detection functionality (or to modify it for testing), an "ENVIRONMENT_BANNER" environment banner can be used with any of the following values (which are case-insensitive):
+The environment banner will attempt to auto-detect the correct environment. To
+override this auto-detection functionality (or to modify it for testing), an
+"ENVIRONMENT_BANNER" environment banner can be used with any of the following
+values (which are case-insensitive):
 
- * "Local"
- * "Development"
- * "Staging"
- * "Production" - This is only needed to force the "production" setting (i.e., not show the banner) on a server that would otherwise show some other value. Production systems do _not_ need to set this value.
+* "Local"
+* "Development"
+* "Staging"
+* "Production" - This is only needed to force the "production" setting (i.e.,
+not show the banner) on a server that would otherwise show some other value.
+Production systems do _not_ need to set this value.
 
 ### Page Content Container class
 
- By default, the content of the page is placed in a \<div> using the Bootstrap "container" class. Applications (such as Annual Staffing Request) may wish to override this setting to use some other class, such as "container-fluid". To do so, add the following "provide" line to your *app/views/layout/application.html.erb* file:
+ By default, the content of the page is placed in a \<div> using the Bootstrap
+ "container" class. Applications (such as Annual Staffing Request) may wish to
+ override this setting to use some other class, such as "container-fluid". To do
+ so, add the following "provide" line to your
+ *app/views/layout/application.html.erb* file:
 
 ```erb
 <% provide :container_class, "container-fluid" %>

--- a/app/assets/stylesheets/umd_lib_environment_banner.scss
+++ b/app/assets/stylesheets/umd_lib_environment_banner.scss
@@ -7,14 +7,4 @@
         background: #008000;
         color: #fff;
     }
-
-    &#environment-development {
-        background: #fff100;
-        color: #000;
-    }
-    
-    &#environment-staging {
-        background: #0000ff;
-        color: #fff;
-    }
 }

--- a/app/helpers/umd_lib_environment_banner_helper.rb
+++ b/app/helpers/umd_lib_environment_banner_helper.rb
@@ -120,7 +120,7 @@ module UMDLibEnvironmentBannerHelper
 
       # Returns true if the banner should be displayed, false otherwise.
       #
-      # text - the text (if any) being displayedin the banner
+      # text - the text (if any) being displayed in the banner
       def banner_enabled(text)
         env_var_enabled = ENV['ENVIRONMENT_BANNER_ENABLED']
         env_var_enabled = ENV.has_key?('ENVIRONMENT_BANNER_ENABLED') ? ENV['ENVIRONMENT_BANNER_ENABLED'] : ''

--- a/app/helpers/umd_lib_environment_banner_helper.rb
+++ b/app/helpers/umd_lib_environment_banner_helper.rb
@@ -1,40 +1,178 @@
 module UMDLibEnvironmentBannerHelper
+  @@banner_initialized = false
+  @@banner = nil
+
+  # Initializes the banner
+  def self.initialize
+    # Uses @@banner_initialized to skip regenerating banner each time the
+    # module is called.
+    if !@@banner_initialized
+      # The EnvVarsEnvironmentBanner banner is used, if enabled, otherwise
+      # defaults to the HostEnvironmentBanner implementation
+      banner = EnvVarsEnvironmentBanner.new
+      if !banner.enabled?
+        banner = HostEnvironmentBanner.new
+      end
+      @@banner = banner
+      @@banner_initialized = true
+    end
+
+    @@banner
+  end
+
   # https://confluence.umd.edu/display/LIB/Create+Environment+Banners
   def umd_lib_environment_banner
-    if environment
-      content_tag :div, "#{environment} Environment",
-        class: 'environment-banner',
-        id: "environment-#{environment.downcase}"
+    if !@@banner_initialized
+      # Uses @@banner_initialized to skip regenerating HTML each time the
+      # method is called.
+      banner = UMDLibEnvironmentBannerHelper.initialize
+
+      # ENVIRONMENT_BANNER_ENABLED always takes precedence
+      if ENV['ENVIRONMENT_BANNER_ENABLED'] == 'false'
+        return @@banner_html = nil
+      end
+
+      if banner.enabled?
+        css_options = banner.css_options
+        # Sort to get consistent ordering of keys
+        css_string = css_options.sort.to_h.map { |key,value| "#{key}='#{value}'" }.join(" ")
+        banner_text = banner.text
+        @@banner_html = "<div #{css_string}>#{banner_text}</div>".html_safe
+        return @@banner_html
+      else
+        @@banner_html = nil
+      end
     end
+    @@banner_html
   end
 
   # When the banner is visible, add the extra-padding-top class
   # to increase body padding
-  def extra_padding_top 
-    if environment
+  def extra_padding_top
+    if @@banner && @@banner.enabled?
       return 'extra-padding-top'
     end
   end
 
-  # Returns 'Local', 'Development', 'Staging', or nil (indicating a production
-  # server), depending on the server environment.
-  #
-  # The "ENVIRONMENT_BANNER" environment variable can optionally be used to
-  # force a particular environment setting. Use "Production" to
-  # indicate a production system on non-production servers.
-  def environment
-    # Allow override using "ENVIRONMENT_BANNER" environment variable.
-    env_var = ENV['ENVIRONMENT_BANNER']
-    return nil if !env_var.nil? && env_var.downcase == 'production'
-    return env_var if !env_var.blank?
-    
-    return 'Local' if Rails.env.development?
-    
-    hostname = `hostname -s`
-    return 'Development' if hostname =~ /dev$/
-    return 'Staging' if hostname =~ /stage$/
-    
-    # Otherwise return nil, indicating production
-  end
+    # Returns an environment banner based on ENV config properties
+    class EnvVarsEnvironmentBanner
+      attr_accessor :text
+      attr_accessor :css_options
 
+      def initialize
+        @text = banner_text
+        @css_options = banner_css_options
+        @enabled = banner_enabled(@text)
+      end
+
+      # Returns the text to display in the environment banner.
+      #
+      # Implementation: Returns the value of the ENVIRONMENT_BANNER property, if
+      # non-empty.
+      #
+      # This method may return nil, if there is no ENVIRONMENT_BANNER
+      def banner_text
+        banner_text = ENV.has_key?('ENVIRONMENT_BANNER') ? ENV['ENVIRONMENT_BANNER'] : ''
+        if !banner_text.empty?
+           ENV['ENVIRONMENT_BANNER'].freeze
+        end
+      end
+
+      # Returns the CSS options to use with the environment banner.
+      #
+      # Implementation: Uses the ENVIRONMENT_BANNER_BACKGROUND and
+      # ENVIRONMENT_BANNER_FOREGROUND properties, if provided.
+      def banner_css_options
+        css_options = {}
+        css_style = ''
+
+        background_color = ENV.has_key?('ENVIRONMENT_BANNER_BACKGROUND') ? ENV['ENVIRONMENT_BANNER_BACKGROUND'] : ''
+        foreground_color = ENV.has_key?('ENVIRONMENT_BANNER_FOREGROUND') ? ENV['ENVIRONMENT_BANNER_FOREGROUND'] : ''
+
+        if !background_color.empty?
+          css_style = "background-color: #{background_color};"
+        end
+
+        if !foreground_color.empty?
+          css_style += " color: #{foreground_color};"
+          css_style.strip!
+        end
+
+        if !css_style.empty?
+          css_options[:style] = css_style
+        end
+
+        css_options[:class] = 'environment-banner'
+        css_options
+      end
+
+      # Returns true if the banner should be displayed, false otherwise.
+      #
+      # text - the text (if any) being displayedin the banner
+      def banner_enabled(text)
+        env_var_enabled = ENV['ENVIRONMENT_BANNER_ENABLED']
+        env_var_enabled = ENV.has_key?('ENVIRONMENT_BANNER_ENABLED') ? ENV['ENVIRONMENT_BANNER_ENABLED'] : ''
+
+        # Don't display the banner if there is no text
+        has_display_text = !text.nil? && !text.empty?
+        return false unless has_display_text
+
+        # Display if ENVIRONMENT_BANNER_ENABLED is not provided or empty
+        return true if env_var_enabled.nil? || env_var_enabled.empty?
+
+        # Any value other than "true" is false
+        env_var_enabled.strip.downcase == 'true'
+      end
+
+      def enabled?
+        @enabled
+      end
+    end
+
+  # Returns an environment banner based on host properties
+  class HostEnvironmentBanner
+    attr_accessor :text
+    attr_accessor :css_options
+
+    def initialize
+      environment_name = environment_name()
+      if environment_name.nil?
+        @enabled = false
+        return
+      end
+      @text = "#{environment_name} Environment"
+      @css_options = {}
+      @css_options[:id] = "environment-#{environment_name.downcase}"
+      @css_options[:class] = "environment-banner"
+      @enabled = !environment_name.empty?
+    end
+
+    def enabled?
+      @enabled
+    end
+
+    private
+
+      def environment_name
+        environment_name_from_host = case Socket.gethostname.split(".").first
+        when /local$/
+         'Local'
+        when /dev$/
+         'Development'
+        when /stage$/
+          'Staging'
+        end
+
+        ( Rails.env.development? || Rails.env.vagrant? ) ? "Local" : environment_name_from_host
+      end
+  end
+end
+
+# here we reopen the ApplicationController (after Rails has started)
+# and stick in our helper module.
+Rails.application.config.after_initialize do
+    ApplicationController.class_eval do
+      include UMDLibEnvironmentBannerHelper
+      helper_method :umd_lib_environment_banner
+    end
 end

--- a/app/helpers/umd_lib_environment_banner_helper.rb
+++ b/app/helpers/umd_lib_environment_banner_helper.rb
@@ -11,13 +11,18 @@ module UMDLibEnvironmentBannerHelper
       # defaults to the HostEnvironmentBanner implementation
       banner = EnvVarsEnvironmentBanner.new
       if !banner.enabled?
-        banner = HostEnvironmentBanner.new
+        banner = DevelopmentEnvironmentBanner.new
       end
       @@banner = banner
       @@banner_initialized = true
     end
 
     @@banner
+  end
+
+  # Resets the banner -- intended be used only for testing
+  def self.reset
+    @@banner_initialized = false
   end
 
   # https://confluence.umd.edu/display/LIB/Create+Environment+Banners
@@ -53,6 +58,9 @@ module UMDLibEnvironmentBannerHelper
       return 'extra-padding-top'
     end
   end
+
+  # Banner implementation classes -- these are not intended to be called
+  # directly
 
     # Returns an environment banner based on ENV config properties
     class EnvVarsEnvironmentBanner
@@ -129,8 +137,8 @@ module UMDLibEnvironmentBannerHelper
       end
     end
 
-  # Returns an environment banner based on host properties
-  class HostEnvironmentBanner
+  # Returns a default environment banner for Rails development environment
+  class DevelopmentEnvironmentBanner
     attr_accessor :text
     attr_accessor :css_options
 
@@ -154,16 +162,7 @@ module UMDLibEnvironmentBannerHelper
     private
 
       def environment_name
-        environment_name_from_host = case Socket.gethostname.split(".").first
-        when /local$/
-         'Local'
-        when /dev$/
-         'Development'
-        when /stage$/
-          'Staging'
-        end
-
-        ( Rails.env.development? || Rails.env.vagrant? ) ? "Local" : environment_name_from_host
+        ( Rails.env.development? || Rails.env.vagrant? ) ? "Local" : nil
       end
   end
 end

--- a/test/helpers/umd_lib_environment_banner_helper_test.rb
+++ b/test/helpers/umd_lib_environment_banner_helper_test.rb
@@ -47,12 +47,32 @@ class UMDLibEnvironmentBannerHelperTest < ActiveSupport::TestCase
       @banner.umd_lib_environment_banner)
   end
 
-  test 'ENVIRONMENT_BANNER_ENABLED of "false" prevent banner display' do
-    ENV['ENVIRONMENT_BANNER'] = 'TestingForegroundAndBackground'
+  test 'ENVIRONMENT_BANNER_ENABLED of "false" prevents banner display' do
+    ENV['ENVIRONMENT_BANNER'] = 'BannerEnabledFalse'
     ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
     ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
     ENV['ENVIRONMENT_BANNER_ENABLED'] = 'false'
     assert_nil(@banner.umd_lib_environment_banner)
+  end
+
+  test 'A blank ENVIRONMENT_BANNER_ENABLED enables banner display' do
+    ENV['ENVIRONMENT_BANNER'] = 'BannerEnabledBlank'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
+    ENV['ENVIRONMENT_BANNER_ENABLED'] = ''
+    assert_equal(
+      "<div class='environment-banner' style='background-color: #777777; color: #ff0000;'>BannerEnabledBlank</div>",
+      @banner.umd_lib_environment_banner)
+  end
+
+  test 'A ENVIRONMENT_BANNER_ENABLED of "true" enables banner display' do
+    ENV['ENVIRONMENT_BANNER'] = 'BannerEnabledTrue'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
+    ENV['ENVIRONMENT_BANNER_ENABLED'] = 'true'
+    assert_equal(
+      "<div class='environment-banner' style='background-color: #777777; color: #ff0000;'>BannerEnabledTrue</div>",
+      @banner.umd_lib_environment_banner)
   end
 
   test 'Banner is not displayed by default in production' do

--- a/test/helpers/umd_lib_environment_banner_helper_test.rb
+++ b/test/helpers/umd_lib_environment_banner_helper_test.rb
@@ -91,6 +91,14 @@ class UMDLibEnvironmentBannerHelperTest < ActiveSupport::TestCase
       @banner.umd_lib_environment_banner)
   end
 
+  test 'Verify that "extra_padding_top" is enabled on first invocation' do
+    banner = Object.new
+    banner.extend(UMDLibEnvironmentBannerHelper)
+
+    Rails.env = 'development'
+    assert_equal('extra-padding-top', banner.extra_padding_top)
+  end
+
   def teardown
     # Unset environment variables
     Rails.env = 'test'

--- a/test/helpers/umd_lib_environment_banner_helper_test.rb
+++ b/test/helpers/umd_lib_environment_banner_helper_test.rb
@@ -1,0 +1,82 @@
+require 'test_helper'
+
+class UMDLibEnvironmentBannerHelperTest < ActiveSupport::TestCase
+  def setup
+    @banner = Object.new
+    @banner.extend(UMDLibEnvironmentBannerHelper)
+  end
+
+  test 'Development environment returns local banner by default' do
+    Rails.env = 'development'
+    assert_equal("<div class='environment-banner' id='environment-local'>Local Environment</div>",
+                 @banner.umd_lib_environment_banner)
+  end
+
+  test 'Vagrant environment returns local banner by default' do
+    Rails.env = 'vagrant'
+    assert_equal("<div class='environment-banner' id='environment-local'>Local Environment</div>",
+                 @banner.umd_lib_environment_banner)
+  end
+
+  test 'Banner text can be controlled by ENVIRONMENT_BANNER' do
+    ENV['ENVIRONMENT_BANNER'] = 'Testing123'
+    assert_equal("<div class='environment-banner'>Testing123</div>",
+                 @banner.umd_lib_environment_banner)
+  end
+
+  test 'Banner foreground color can be controlled by ENVIRONMENT_BANNER_FOREGROUND' do
+    ENV['ENVIRONMENT_BANNER'] = 'TestingForeground'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
+    assert_equal("<div class='environment-banner' style='color: #ff0000;'>TestingForeground</div>",
+                 @banner.umd_lib_environment_banner)
+  end
+
+  test 'Banner background color can be controlled by ENVIRONMENT_BANNER_BACKGROUND' do
+    ENV['ENVIRONMENT_BANNER'] = 'TestingBackground'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#ff00ff'
+    assert_equal("<div class='environment-banner' style='background-color: #ff00ff;'>TestingBackground</div>",
+                 @banner.umd_lib_environment_banner)
+  end
+
+  test 'Banner foreground and background color can be controlled by environment variables' do
+    ENV['ENVIRONMENT_BANNER'] = 'TestingForeBack'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
+    assert_equal(
+      "<div class='environment-banner' style='background-color: #777777; color: #ff0000;'>TestingForeBack</div>",
+      @banner.umd_lib_environment_banner)
+  end
+
+  test 'ENVIRONMENT_BANNER_ENABLED of "false" prevent banner display' do
+    ENV['ENVIRONMENT_BANNER'] = 'TestingForegroundAndBackground'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
+    ENV['ENVIRONMENT_BANNER_ENABLED'] = 'false'
+    assert_nil(@banner.umd_lib_environment_banner)
+  end
+
+  test 'Banner is not displayed by default in production' do
+    Rails.env = 'production'
+    assert_nil(@banner.umd_lib_environment_banner)
+  end
+
+  test 'Banner can be displayed in production using environment variables' do
+    Rails.env = 'production'
+
+    ENV['ENVIRONMENT_BANNER'] = 'TestingProdWithEnv'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
+    assert_equal(
+      "<div class='environment-banner' style='background-color: #777777; color: #ff0000;'>TestingProdWithEnv</div>",
+      @banner.umd_lib_environment_banner)
+  end
+
+  def teardown
+    # Unset environment variables
+    Rails.env = 'test'
+    ENV.clear
+
+    # Reset the module
+    UMDLibEnvironmentBannerHelper.reset
+  end
+end

--- a/test/helpers/umd_lib_environment_banner_helper_test.rb
+++ b/test/helpers/umd_lib_environment_banner_helper_test.rb
@@ -47,12 +47,14 @@ class UMDLibEnvironmentBannerHelperTest < ActiveSupport::TestCase
       @banner.umd_lib_environment_banner)
   end
 
-  test 'ENVIRONMENT_BANNER_ENABLED of "false" prevents banner display' do
-    ENV['ENVIRONMENT_BANNER'] = 'BannerEnabledFalse'
+  test 'A ENVIRONMENT_BANNER_ENABLED of "true" enables banner display' do
+    ENV['ENVIRONMENT_BANNER'] = 'BannerEnabledTrue'
     ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
     ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
-    ENV['ENVIRONMENT_BANNER_ENABLED'] = 'false'
-    assert_nil(@banner.umd_lib_environment_banner)
+    ENV['ENVIRONMENT_BANNER_ENABLED'] = 'true'
+    assert_equal(
+      "<div class='environment-banner' style='background-color: #777777; color: #ff0000;'>BannerEnabledTrue</div>",
+      @banner.umd_lib_environment_banner)
   end
 
   test 'A blank ENVIRONMENT_BANNER_ENABLED enables banner display' do
@@ -65,14 +67,20 @@ class UMDLibEnvironmentBannerHelperTest < ActiveSupport::TestCase
       @banner.umd_lib_environment_banner)
   end
 
-  test 'A ENVIRONMENT_BANNER_ENABLED of "true" enables banner display' do
-    ENV['ENVIRONMENT_BANNER'] = 'BannerEnabledTrue'
+  test 'ENVIRONMENT_BANNER_ENABLED of "false" prevents banner display' do
+    ENV['ENVIRONMENT_BANNER'] = 'BannerEnabledFalse'
     ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
     ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
-    ENV['ENVIRONMENT_BANNER_ENABLED'] = 'true'
-    assert_equal(
-      "<div class='environment-banner' style='background-color: #777777; color: #ff0000;'>BannerEnabledTrue</div>",
-      @banner.umd_lib_environment_banner)
+    ENV['ENVIRONMENT_BANNER_ENABLED'] = 'false'
+    assert_nil(@banner.umd_lib_environment_banner)
+  end
+
+  test 'Non-blank ENVIRONMENT_BANNER_ENABLED other than "true" prevents banner display' do
+    ENV['ENVIRONMENT_BANNER'] = 'BannerEnabledFoobar'
+    ENV['ENVIRONMENT_BANNER_FOREGROUND'] = '#ff0000'
+    ENV['ENVIRONMENT_BANNER_BACKGROUND'] = '#777777'
+    ENV['ENVIRONMENT_BANNER_ENABLED'] = 'foobar'
+    assert_nil(@banner.umd_lib_environment_banner)
   end
 
   test 'Banner is not displayed by default in production' do

--- a/umd_lib_style.gemspec
+++ b/umd_lib_style.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 4.2.6"
 
-  # Restrict to Rails 4.2.x for development, so that tests will run
+  # Restrict to Rails 4.2.x and sqlite3 for development, so that tests will run
   s.add_development_dependency "rails", "~> 4.2.6"
-  s.add_development_dependency "sqlite3"
+  s.add_development_dependency "sqlite3", "~> 1.3.11"
 end


### PR DESCRIPTION
Refactored the "environment banner" implementation to better support use in Kubernetes. Largely followed the approach taken in ArchivesSpace, where the following variables are available for setting the banner:

* ENVIRONMENT_BANNER - the text for the banner
* ENVIRONMENT_BANNER_BACKGROUND - The background color of the banner (in CSS notation)
* ENVIRONMENT_BANNER_FOREGROUND - The foreground color of the banner (in CSS notation)
* ENVIRONMENT_BANNER_ENABLED - "true" (or present, but blank) if the banner should be enabled. Any other (non-empty) value is treated as false

Automatic configuration of the banner based on the hostname (i.e., the autodiscovery of "dev" and "stage" servers), is no longer provided.

The local development environment is still auto-detected (and displays a "Local Development" banner) when the "Rails.env.development?" or "Rails.env.vargant?" methods return true. Setting the environment variables above overrides this behavior.

**Note**: The removal of hostname-based configuration represents an API-breaking change, so the version number should be incremented to 2.0.0.

https://issues.umd.edu/browse/LIBITD-1794